### PR TITLE
Introduce cell slots

### DIFF
--- a/nicegui_tabulator/__init__.py
+++ b/nicegui_tabulator/__init__.py
@@ -1,4 +1,5 @@
 from .version import __version__
 from .core.tabulator import Tabulator as tabulator
+from .core.types import CellSlotProps
 
-__all__ = ["__version__", "tabulator"]
+__all__ = ["__version__", "tabulator", "CellSlotProps"]

--- a/nicegui_tabulator/core/tabulator.js
+++ b/nicegui_tabulator/core/tabulator.js
@@ -104,5 +104,10 @@ export default {
       this.table.updateColumnDefinition(field, definition);
     },
 
+    updateCellSlot(field, rowNumber) {
+      this.$emit('updateCellSlot', { field, rowNumber })
+    },
+
+
   },
 };

--- a/nicegui_tabulator/core/tabulator.py
+++ b/nicegui_tabulator/core/tabulator.py
@@ -224,7 +224,7 @@ class Tabulator(Element, component="tabulator.js", libraries=["libs/tabulator.mi
 
         return cls(options)
 
-    def cell_slot(
+    def add_cell_slot(
         self,
         field: str,
     ):
@@ -234,8 +234,6 @@ class Tabulator(Element, component="tabulator.js", libraries=["libs/tabulator.mi
             def fn(row_number: int):
                 options = self._props["options"]
                 data = options.get("data", [])
-                # columns = options.get("columns", [])
-
                 if not data:
                     return
 

--- a/nicegui_tabulator/core/tabulator.py
+++ b/nicegui_tabulator/core/tabulator.py
@@ -53,6 +53,11 @@ class Tabulator(Element, component="tabulator.js", libraries=["libs/tabulator.mi
 
         self.on("updateCellSlot", on_update_cell_slot)
 
+    def delete(self) -> None:
+        for tp in self._teleport_slots_cache.values():
+            tp.delete()
+        return super().delete()
+
     def on_event(
         self,
         event: str,
@@ -285,7 +290,7 @@ class Tabulator(Element, component="tabulator.js", libraries=["libs/tabulator.mi
                 const field = cell.getField();
                 const rowNumber = row.getIndex();
                 const target = cell.getElement();
-                target.innerHTML = `<div class="ng-cell-slot-${{field}}-${{rowNumber}}"></div>`
+                target.innerHTML = `<div class="ng-cell-slot-${{field}}-${{rowNumber}} fit"></div>`
                 const table = getElement({self.id});
                 runMethod(table, 'updateCellSlot',[field,rowNumber]);
             }});

--- a/nicegui_tabulator/core/tabulator.py
+++ b/nicegui_tabulator/core/tabulator.py
@@ -228,6 +228,29 @@ class Tabulator(Element, component="tabulator.js", libraries=["libs/tabulator.mi
         self,
         field: str,
     ):
+        """
+        Add a cell slot to the table.
+
+        @see https://github.com/CrystalWindSnake/nicegui-tabulator?tab=readme-ov-file#cell-slots
+
+
+        Args:
+            field (str): The field name of the column you want to add a cell slot to.
+
+
+        ## Example Usage
+
+        ```python
+        from nicegui import ui
+        from nicegui_tabulator import tabulator,CellSlotProps
+
+        table = tabulator({...})
+
+        @table.add_cell_slot("name")
+        def name_cell(props: CellSlotProps):
+            ui.input(value=props.value, placeholder="Enter name")
+
+        """
         id = f"c{self.id}"
 
         def wrapper(build_fn: Callable[[CellSlotProps], None]):

--- a/nicegui_tabulator/core/teleport.js
+++ b/nicegui_tabulator/core/teleport.js
@@ -1,6 +1,17 @@
 export default {
-  template: `<Teleport :to="to"><slot></slot></Teleport>`,
+  template: `<Teleport :to="to" :key="key"><slot></slot></Teleport>`,
   props: {
     to: String,
   },
+  data() {
+    return {
+      key: 0,
+    };
+  },
+  methods: {
+    forceUpdate() {
+      // console.log('forceUpdate', this.to);
+      this.key++;
+    }
+  }
 };

--- a/nicegui_tabulator/core/teleport.js
+++ b/nicegui_tabulator/core/teleport.js
@@ -10,7 +10,6 @@ export default {
   },
   methods: {
     forceUpdate() {
-      // console.log('forceUpdate', this.to);
       this.key++;
     }
   }

--- a/nicegui_tabulator/core/teleport.js
+++ b/nicegui_tabulator/core/teleport.js
@@ -1,0 +1,6 @@
+export default {
+  template: `<Teleport :to="to"><slot></slot></Teleport>`,
+  props: {
+    to: String,
+  },
+};

--- a/nicegui_tabulator/core/teleport.py
+++ b/nicegui_tabulator/core/teleport.py
@@ -7,5 +7,8 @@ class Teleport(Element, component="teleport.js"):
         super().__init__()
         self._props["to"] = to
 
+    def forceUpdate(self):
+        self.run_method("forceUpdate")
+
 
 teleport = Teleport

--- a/nicegui_tabulator/core/teleport.py
+++ b/nicegui_tabulator/core/teleport.py
@@ -1,0 +1,11 @@
+from nicegui.element import Element
+
+
+class Teleport(Element, component="teleport.js"):
+    def __init__(self, to: str) -> None:
+        """ """
+        super().__init__()
+        self._props["to"] = to
+
+
+teleport = Teleport

--- a/nicegui_tabulator/core/types.py
+++ b/nicegui_tabulator/core/types.py
@@ -1,5 +1,11 @@
-from dataclasses import dataclass
+from __future__ import annotations
+from dataclasses import dataclass, field as dc_field
 from typing import Any, Dict
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tabulator import Tabulator
 
 
 @dataclass
@@ -8,3 +14,14 @@ class CellSlotProps:
     value: Any
     row: Dict
     row_number: int
+    table: Tabulator = dc_field(init=True, repr=False)
+
+    def update_value(self, value):
+        id = self.row["id"]
+
+        options = self.table._props["options"]
+        data = options["data"]
+
+        data[self.row_number - 1].update({self.field: value})
+
+        # self.table.run_table_method("updateData", [{"id": id, self.field: value}])

--- a/nicegui_tabulator/core/types.py
+++ b/nicegui_tabulator/core/types.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class CellSlotProps:
+    field: str
+    value: Any
+    row: Dict
+    row_number: int

--- a/nicegui_tabulator/core/types.py
+++ b/nicegui_tabulator/core/types.py
@@ -17,11 +17,5 @@ class CellSlotProps:
     table: Tabulator = dc_field(init=True, repr=False)
 
     def update_value(self, value):
-        id = self.row["id"]
-
-        options = self.table._props["options"]
-        data = options["data"]
-
+        data = self.table._props["options"]["data"]
         data[self.row_number - 1].update({self.field: value})
-
-        # self.table.run_table_method("updateData", [{"id": id, self.field: value}])


### PR DESCRIPTION
New feature: Cell slots enable complete customization of cell content. Insert any component without the need for string templates.

```python
from nicegui import ui
from nicegui_tabulator import tabulator, CellSlotProps


tabledata = [
    {"id": 1, "name": "Oli Bob", "age": "12", "col": "red"},
    {"id": 2, "name": "Mary May", "age": "1", "col": "blue"},
    {"id": 3, "name": "Chr", "age": "42", "col": "green"},
]

table_config = {
    "data": tabledata,
    "pagination": "local",
    "paginationSize": 2,
    "columns": [
        {"title": "Name", "field": "name"},
        {"title": "Age", "field": "age", "width": "200"},
        {"title": "Favourite Color", "field": "col"},
    ],
    "printConfig": {
        "formatCells": False,
    },
}

table1 = tabulator(table_config)


@table1.add_cell_slot("col")
def color_cell(props: CellSlotProps):
    with ui.row().classes("fit flex-center"):
        ui.icon("home", color=props.row["col"], size="1.5rem").on(
            "click",
            lambda: ui.notify(f"you clicked on {props.field} , value:{props.value}"),
        )
        ui.label(props.value)


@table1.add_cell_slot("age")
def age_cell(props: CellSlotProps):
    def on_change(e):
        value.set_text(str(e.value))
        message.set_text(
            f"you changed the age of row [row:{props.row_number},col:{props.field}]，value:{e.value}"
        )

        props.update_value(e.value)

    value = ui.label(props.value).style("font-weight: bold;")
    ui.slider(
        min=0,
        max=100,
        value=int(props.value),
        on_change=on_change,
    )


message = ui.label()


def print_table():
    table1.run_table_method("setData", table1._props["options"]["data"])
    table1.run_table_method("print", True)


ui.button(
    "print",
    on_click=print_table,
)


ui.run()
```