### PR TITLE
Fix the misalignment of props.row_number in the `add_cell_slot` method.

### DIFF
--- a/nicegui_tabulator/core/tabulator.py
+++ b/nicegui_tabulator/core/tabulator.py
@@ -289,7 +289,7 @@ class Tabulator(Element, component="tabulator.js", libraries=["libs/tabulator.mi
             onRendered(function(){{
                 const row = cell.getRow();
                 const field = cell.getField();
-                const rowNumber = row.getIndex();
+                const rowNumber = row.getPosition();
                 const target = cell.getElement();
                 target.innerHTML = `<div class="ng-cell-slot-${{field}}-${{rowNumber}} fit"></div>`
                 const table = getElement({self.id});


### PR DESCRIPTION
As stated in the title.